### PR TITLE
adding function org-olp-refile [WIP]

### DIFF
--- a/org-olp.el
+++ b/org-olp.el
@@ -130,4 +130,26 @@ heading."
         (olp (apply 'org-olp-make-olp file-name olp)))
     (org-olp--goto file-name olp)))
 
+(defun org-olp-refile (file-name olp-src olp-dst)
+  "This function takes a filename and two olp paths it uses the
+org-element api to remove the heading specified by the first olp and
+then inserts the element *under* the heading pointed to by the second olp
+"
+  (progn
+    (org-olp-visit file-name olp-src)
+    ;; identify beginning and end points of the current org element
+    ;; "cut" the current element into the kill ring
+    ;; seek to the other element and yank(paste) the contents of the kill ring
+    ;; after that heading
+    (let ((p-begin (org-element-property :begin (org-element-at-point) ))
+          (p-end   (org-element-property :end (org-element-at-point)))
+          )
+      (kill-region p-begin p-end)
+      (org-olp-visit file-name olp-dst)
+      (end-of-line)
+      (insert "\n")
+      (yank)
+      )
+    ))
+
 (provide 'org-olp)

--- a/org-olp.el
+++ b/org-olp.el
@@ -167,10 +167,9 @@ then inserts the element *under* the heading pointed to by the second olp
                                                ))
               ((< src-level (+ dst-level 1)) (progn
                                                (message "[DBG] lower level")
-                                               (goto-char dst-contents-end)
-                                               (org-paste-subtree)
-                                               ;; (previous-line)
-                                               (org-demote-subtree)
+                                               (org-olp--goto-end)
+                                               (insert "\n")
+                                               (org-paste-subtree (+ dst-level 1))
                                                ))
               )
         ))

--- a/org-olp.el
+++ b/org-olp.el
@@ -131,11 +131,20 @@ heading."
     (org-olp--goto file-name olp)))
 
 
+
+;; either go to the end of line or to the end of the content for that element
+(defun org-olp--goto-end ()
+  (let ((cend (org-element-property :contents-end (org-element-at-point))))
+    (goto-char (if cend cend (point-at-eol)))
+    ))
+
+
 (defun org-olp-refile (file-name olp-src olp-dst)
   "This function takes a filename and two olp paths it uses the
 org-element api to remove the heading specified by the first olp and
 then inserts the element *under* the heading pointed to by the second olp
 "
+
   (progn
     (org-olp-visit file-name olp-src)
     (let ((src-level (org-element-property :level (org-element-at-point))))
@@ -146,26 +155,15 @@ then inserts the element *under* the heading pointed to by the second olp
             )
         (cond ((= src-level (+ dst-level 1)) (progn
                                                (message "[DBG] same level")
-                                               (if dst-contents-end
-                                                   (progn
-                                                     (message "[DBG] not eof")
-                                                     ;; not EOF
-                                                     (goto-char dst-contents-end)
-                                                     (org-paste-subtree)
-                                                     )
-                                                 (progn
-                                                   ;; EOF
-                                                   (message "[DBG] eof")
-                                                   (next-line)
-                                                   (org-paste-subtree)
-                                                   (beginning-of-line)
-                                                   (org-demote-subtree)
-                                                   ))
+                                               (org-olp--goto-end)
+                                               (insert "\n")
+                                               (org-paste-subtree (+ dst-level 1))
                                                ))
               ((> src-level (+ dst-level 1)) (progn
                                                (message "[DBG] higher level")
-                                               (org-next-visible-heading 1)
-                                               (org-paste-subtree)
+                                               (org-olp--goto-end)
+                                               (insert "\n")
+                                               (org-paste-subtree (+ dst-level 1))
                                                ))
               ((< src-level (+ dst-level 1)) (progn
                                                (message "[DBG] lower level")

--- a/org-olp.el
+++ b/org-olp.el
@@ -131,32 +131,6 @@ heading."
     (org-olp--goto file-name olp)))
 
 
-;; This refiling approach is more raw and is not prefered.
-;; It also doesn't feature any level-adapting logic.
-(defun org-olp-refile--old (file-name olp-src olp-dst)
-  "This function takes a filename and two olp paths it uses the
-org-element api to remove the heading specified by the first olp and
-then inserts the element *under* the heading pointed to by the second olp
-"
-  (progn
-    (org-olp-visit file-name olp-src)
-    ;; identify beginning and end points of the current org element
-    ;; "cut" the current element into the kill ring
-    ;; seek to the other element and yank(paste) the contents of the kill ring
-    ;; after that heading
-    (let ((p-begin (org-element-property :begin (org-element-at-point) ))
-          (p-end   (org-element-property :end (org-element-at-point)))
-          )
-      (kill-region p-begin p-end)
-      (org-olp-visit file-name olp-dst)
-      (end-of-line)
-      (insert "\n")
-      (yank)
-      )
-    ))
-
-
-
 (defun org-olp-refile (file-name olp-src olp-dst)
   "This function takes a filename and two olp paths it uses the
 org-element api to remove the heading specified by the first olp and

--- a/org-olp.org
+++ b/org-olp.org
@@ -109,7 +109,14 @@
               (org-olp--pick-olp file-name children olp)
             olp))))
 #+end_src
-
+*** org-olp--goto-end
+#+begin_src emacs-lisp
+(defun org-olp--goto-end ()
+  "Either go to the end of line or to the end of the content for that element"
+  (let ((cend (org-element-property :contents-end (org-element-at-point))))
+    (goto-char (if cend cend (point-at-eol)))
+    ))
+#+end_src
 ** public
 *** org-olp-visit
 #+begin_src emacs-lisp
@@ -172,7 +179,41 @@
           (olp (apply 'org-olp-recursive-select file-name olp)))
       (org-olp-visit file-name olp)))
 #+end_src
+*** org-olp-refile
+#+BEGIN_SRC emacs-lisp
+(defun org-olp-refile (file-name olp-src olp-dst)
+  "This function takes a filename and two olp paths it uses the
+org-element api to remove the heading specified by the first olp and
+then inserts the element *under* the heading pointed to by the second olp
+"
 
+  (progn
+    (org-olp-visit file-name olp-src)
+    (let ((src-level (org-element-property :level (org-element-at-point))))
+      (org-cut-subtree)
+      (org-olp-visit file-name olp-dst)
+      (let ((dst-level (org-element-property :level (org-element-at-point)))
+            (dst-contents-end (org-element-property :contents-end (org-element-at-point)))
+            )
+        (cond ((= src-level (+ dst-level 1)) (progn
+                                               (org-olp--goto-end)
+                                               (insert "\n")
+                                               (org-paste-subtree (+ dst-level 1))
+                                               ))
+              ((> src-level (+ dst-level 1)) (progn
+                                               (org-olp--goto-end)
+                                               (insert "\n")
+                                               (org-paste-subtree (+ dst-level 1))
+                                               ))
+              ((< src-level (+ dst-level 1)) (progn
+                                               (org-olp--goto-end)
+                                               (insert "\n")
+                                               (org-paste-subtree (+ dst-level 1))
+                                               ))
+              )
+        ))
+    ))
+#+END_SRC
 ** provides
 #+begin_src emacs-lisp
   (provide 'org-olp)

--- a/readme.org
+++ b/readme.org
@@ -14,3 +14,10 @@ children is reached. The resulting olp is returned.
 ** =org-olp-jump= (file-name &rest olp)
 Run org-olp-recursive-select on FILE-NAME, starting from OLP or top-level, then visit
 the selected heading.
+** =org-olp-find= (file-name &rest olp)
+Run org-olp-recursive-select on FILE-NAME, starting from OLP or
+top-level, then visit the selected heading.
+** =org-olp-refile= (file-name olp-src olp-dst)
+This function takes a filename and two olp paths it uses the
+org-element api to remove the heading specified by the first olp and
+then inserts the element *under* the heading pointed to by the second olp

--- a/readme.org
+++ b/readme.org
@@ -11,9 +11,6 @@ Run org-olp-select then visit the resulting olp in FILE-NAME
 ** =org-olp-recursive-select= (file-name &rest olp)
 Select headings from FILE-NAME, from OLP or top-level, until a heading with no
 children is reached. The resulting olp is returned.
-** =org-olp-jump= (file-name &rest olp)
-Run org-olp-recursive-select on FILE-NAME, starting from OLP or top-level, then visit
-the selected heading.
 ** =org-olp-find= (file-name &rest olp)
 Run org-olp-recursive-select on FILE-NAME, starting from OLP or
 top-level, then visit the selected heading.

--- a/tests.el
+++ b/tests.el
@@ -4,56 +4,149 @@
 ;; emacs -batch -l ert -l tests.el -f ert-run-tests-batch-and-exit
 ;;
 
-
-
 ;; Add the current path to load paths so we can load org-olp from here
 (add-to-list 'load-path ".")
-
 ;;;; Use a custom version of org-mode
-;; (add-to-list 'load-path "~/sources/olp/org-mode/lisp")
+(add-to-list 'load-path "~/sources/olp/org-mode/lisp")
 
 (require 'ert)
 (require 'org)
 (require 'org-olp)
 
+(defun test-refile-helper (input out-file olp-src olp-dst)
+  ;; write input data on disk
+  (with-temp-buffer (insert input) (write-file out-file nil)
+                    ;; run our refiling routine
+                    (org-olp-refile out-file olp-src olp-dst)
+                    ;; save modified org file to disk in the same location
+                    (save-buffer)
+                    ;; return the modified file contents after refiling
+                    (let ((modified-contents
+                           (with-temp-buffer
+                             (insert-file-contents out-file)
+                             (buffer-string)
+                             )))
+                      modified-contents
+                      )))
+
 ;; Print the org-mode version
 (message (concat "[DEBUG] Org version => " (prin1-to-string org-version)))
 
-;; Test if an element is moved correctly under a same-level parent heading
-;; as the original one.
+
+
+;; (a12 moves under a2 ; same level)
 (ert-deftest refiling-test-same-level ()
   (progn
     (interactive)
-    (let ((input "* a1
+    (let* ((input "* a1
 ** a12
 content12
 ** a13
 content14
 * a2
 ")
-          (expected "* a1
+           (expected "* a1
 ** a13
 content14
 * a2
 ** a12
-content12
-
-"))
-      ;; write input data on disk
-      (with-temp-buffer (insert input) (write-file "/tmp/f1.org" nil))
-      ;; run our refiling routine
-      (org-olp-refile "/tmp/f1.org" (list "a1" "a12") (list "a2"))
-      ;; save modified org file to disk in the same location
-      (save-buffer)
-      
-      ;; check to see if we got the expected result
-      (let ((output
-             (with-temp-buffer
-               (insert-file-contents "/tmp/f1.org")
-               (buffer-string)
-               )))
-        (should (equal output expected)))
+ content12
+")
+           (output (test-refile-helper input "/tmp/f1.org" (list "a1" "a12") (list "a2")))
+           )
+      (should (equal output expected))
       )))
 
 
+;; (a151 moves under a1 ; higher level)
+(ert-deftest refiling-test-higher-level ()
+  (progn
+    (interactive)
+    (let* ((input "* a1
+** a12
+content12
+** a13
+content13
+** a14
+content14
+** a15
+content15
+*** a151
+content151
+*** a152
+content152
+*** a153
+content153
+*** a154
+content154
+")
+           (expected "* a1
+** a151
+content151
+** a12
+content12
+** a13
+content13
+** a14
+content14
+** a15
+content15
+*** a152
+content152
+*** a153
+content153
+*** a154
+content154
+")
+           (output (test-refile-helper input "/tmp/f1.org" (list "a1" "a15" "a151") (list "a1")))
+           )
+      (should (equal output expected))
+      )))
+
+
+
+;; (a14 moves under a153 ; lower level)
+(ert-deftest refiling-test-lower-level ()
+  (progn
+    (interactive)
+    (let* ((input "* a1
+** a12
+content12
+** a13
+content13
+** a14
+content14
+** a15
+content15
+*** a151
+content151
+*** a152
+content152
+*** a153
+content153
+*** a154
+content154
+")
+           (expected "* a1
+** a12
+content12
+** a13
+content13
+** a15
+content15
+*** a151
+content151
+*** a152
+content152
+*** a153
+content153
+**** a14
+  content14
+*** a154
+content154
+")
+           (output (test-refile-helper input "/tmp/f1.org" (list "a1" "a14") (list "a1" "a15" "a153")))
+           )
+      (should (equal output expected))
+      )))
 

--- a/tests.el
+++ b/tests.el
@@ -1,0 +1,59 @@
+;;
+;; These tests can be run like so:
+;;
+;; emacs -batch -l ert -l tests.el -f ert-run-tests-batch-and-exit
+;;
+
+
+
+;; Add the current path to load paths so we can load org-olp from here
+(add-to-list 'load-path ".")
+
+;;;; Use a custom version of org-mode
+;; (add-to-list 'load-path "~/sources/olp/org-mode/lisp")
+
+(require 'ert)
+(require 'org)
+(require 'org-olp)
+
+;; Print the org-mode version
+(message (concat "[DEBUG] Org version => " (prin1-to-string org-version)))
+
+;; Test if an element is moved correctly under a same-level parent heading
+;; as the original one.
+(ert-deftest refiling-test-same-level ()
+  (progn
+    (interactive)
+    (let ((input "* a1
+** a12
+content12
+** a13
+content14
+* a2
+")
+          (expected "* a1
+** a13
+content14
+* a2
+** a12
+content12
+
+"))
+      ;; write input data on disk
+      (with-temp-buffer (insert input) (write-file "/tmp/f1.org" nil))
+      ;; run our refiling routine
+      (org-olp-refile "/tmp/f1.org" (list "a1" "a12") (list "a2"))
+      ;; save modified org file to disk in the same location
+      (save-buffer)
+      
+      ;; check to see if we got the expected result
+      (let ((output
+             (with-temp-buffer
+               (insert-file-contents "/tmp/f1.org")
+               (buffer-string)
+               )))
+        (should (equal output expected)))
+      )))
+
+
+

--- a/tests.el
+++ b/tests.el
@@ -7,7 +7,7 @@
 ;; Add the current path to load paths so we can load org-olp from here
 (add-to-list 'load-path ".")
 ;;;; Use a custom version of org-mode
-(add-to-list 'load-path "~/sources/olp/org-mode/lisp")
+;; (add-to-list 'load-path "~/sources/olp/org-mode/lisp")
 
 (require 'ert)
 (require 'org)
@@ -15,8 +15,7 @@
 
 ;; This is actually in place to make the tests pass
 ;; even though a bug surfaced in org-mode itself.
-;; The bug in org-mode surfaced on 9.1.6 but does is not
-;; present on 8.2.10
+;; The bug is present in 9.1.6 but not in 8.2.10
 ;;
 ;; Bug description: the org-paste-subtree function inserts leading whitespace
 ;; into the contents of the subtree. The reasonable expectation here is that
@@ -28,8 +27,9 @@
   )
 
 (defun test-refile-helper (input out-file olp-src olp-dst)
-  ;; write input data on disk
-  (with-temp-buffer (insert input) (write-file out-file nil)
+  (with-temp-buffer (insert input)
+                    ;; write input data on disk
+                    (write-file out-file nil)
                     ;; run our refiling routine
                     (org-olp-refile out-file olp-src olp-dst)
                     ;; save modified org file to disk in the same location

--- a/tests.el
+++ b/tests.el
@@ -13,6 +13,20 @@
 (require 'org)
 (require 'org-olp)
 
+;; This is actually in place to make the tests pass
+;; even though a bug surfaced in org-mode itself.
+;; The bug in org-mode surfaced on 9.1.6 but does is not
+;; present on 8.2.10
+;;
+;; Bug description: the org-paste-subtree function inserts leading whitespace
+;; into the contents of the subtree. The reasonable expectation here is that
+;; org-paste-subtree should only paste the original content extracted by
+;; org-cut-subtree and not alter it in any way.
+;;
+(defun remove-leading-whitespace (s)
+  (replace-regexp-in-string "^\s*" "" s)
+  )
+
 (defun test-refile-helper (input out-file olp-src olp-dst)
   ;; write input data on disk
   (with-temp-buffer (insert input) (write-file out-file nil)
@@ -26,7 +40,8 @@
                              (insert-file-contents out-file)
                              (buffer-string)
                              )))
-                      modified-contents
+                      ;; modified-contents
+                      (remove-leading-whitespace modified-contents)
                       )))
 
 ;; Print the org-mode version
@@ -50,13 +65,12 @@ content14
 content14
 * a2
 ** a12
- content12
+content12
 ")
            (output (test-refile-helper input "/tmp/f1.org" (list "a1" "a12") (list "a2")))
            )
       (should (equal output expected))
       )))
-
 
 ;; (a151 moves under a1 ; higher level)
 (ert-deftest refiling-test-higher-level ()
@@ -141,7 +155,7 @@ content152
 *** a153
 content153
 **** a14
-  content14
+content14
 *** a154
 content154
 ")

--- a/tests.el
+++ b/tests.el
@@ -7,7 +7,7 @@
 ;; Add the current path to load paths so we can load org-olp from here
 (add-to-list 'load-path ".")
 ;;;; Use a custom version of org-mode
-;; (add-to-list 'load-path "~/sources/olp/org-mode/lisp")
+(add-to-list 'load-path "~/sources/olp/org-mode/lisp")
 
 (require 'ert)
 (require 'org)
@@ -59,11 +59,14 @@ content12
 ** a13
 content14
 * a2
+a2
 ")
            (expected "* a1
 ** a13
 content14
 * a2
+a2
+
 ** a12
 content12
 ")
@@ -95,8 +98,6 @@ content153
 content154
 ")
            (expected "* a1
-** a151
-content151
 ** a12
 content12
 ** a13
@@ -111,6 +112,9 @@ content152
 content153
 *** a154
 content154
+
+** a151
+content151
 ")
            (output (test-refile-helper input "/tmp/f1.org" (list "a1" "a15" "a151") (list "a1")))
            )

--- a/tests.el
+++ b/tests.el
@@ -158,6 +158,7 @@ content151
 content152
 *** a153
 content153
+
 **** a14
 content14
 *** a154


### PR DESCRIPTION
org-olp-refile takes a source and a destination olp and refiles the source under the destination assuming they're at the same level (similar functionality is already in place via org-refile does)

Tests written using ert are part of this commit as well.